### PR TITLE
Fix InsideClipboard manifest

### DIFF
--- a/bucket/insideclipboard.json
+++ b/bucket/insideclipboard.json
@@ -3,8 +3,7 @@
     "checkver": "InsideClipboard v([\\d.]+)",
     "version": "1.15",
     "license": "freeware",
-    "description": "Each time that you copy something into the clipboard for pasting it into another application, the copied data is saved into multiple formats. The main clipboard application of Windows only display the basic clipboard formats, like text and bitmaps, but doesn't display the list of all formats that are stored in the clipboard.
-InsideClipboard is a small utility that displays the binary content of all formats that are currently stored in the clipboard, and allow you to save the content of specific format into a binary file.",
+    "description": "Each time that you copy something into the clipboard for pasting it into another application, the copied data is saved into multiple formats. The main clipboard application of Windows only display the basic clipboard formats, like text and bitmaps, but doesn't display the list of all formats that are stored in the clipboard. InsideClipboard is a small utility that displays the binary content of all formats that are currently stored in the clipboard, and allow you to save the content of specific format into a binary file.",
     "url": "https://www.nirsoft.net/utils/insideclipboard.zip",
     "hash": "fe5052f6efc39f5f223b32006616841eb95c08eb8f85acff41f502ba883d7737",
     "autoupdate": {


### PR DESCRIPTION
Hi,

I noticed that my script over at https://github.com/mertd/shovel-data (generates a searchable json file for [Shovel](https://shovel.sh) generated incorrect JSON. Turns out there is a line break that renders the InsideClipboard manifest json invalid.

This PR simply removes the line break.