### PR TITLE
Update usbdeview to version 3.02

### DIFF
--- a/bucket/usbdeview.json
+++ b/bucket/usbdeview.json
@@ -1,17 +1,29 @@
 {
     "homepage": "https://www.nirsoft.net/utils/usb_devices_view.html",
     "checkver": "USBDeview v([\\d.]+)",
-    "version": "3.01",
+    "version": "3.02",
     "license": "freeware",
     "description": "USBDeview is a small utility that lists all USB devices that currently connected to your computer, as well as all USB devices that you previously used. For each USB device, extended information is displayed: Device name/description, device type, serial number (for mass storage devices), the date/time that device was added, VendorID, ProductID, and more... USBDeview also allows you to uninstall USB devices that you previously used, disconnect USB devices that are currently connected to your computer, as well as to disable and enable USB devices. You can also use USBDeview on a remote computer, as long as you login to that computer with admin user.",
     "architecture": {
         "64bit": {
-            "url": "https://www.nirsoft.net/utils/usbdeview-x64.zip",
-            "hash": "bc64eb677027f19e8bade7eeaba9b0b820d524aeec42c7ee92e3fd651ccf3d7a"
+            "url": [
+                "https://www.nirsoft.net/utils/usbdeview-x64.zip",
+                "http://www.linux-usb.org/usb.ids"
+            ],
+            "hash": [
+                "1802eccdc6eed1f1b5b50c59344677394c1b4a0590fe34450909ad13e3823cdd",
+                "29fa9082f1377dd565232f891a47b87eb652cc8b87002c34b4b43142f9816e1d"
+            ]
         },
         "32bit": {
-            "url": "https://www.nirsoft.net/utils/usbdeview.zip",
-            "hash": "8305bc7fb568395d484b6c1ff84d1c8d12454307f9d2906d54d19ea8b385771c"
+            "url": [
+                "https://www.nirsoft.net/utils/usbdeview.zip",
+                "http://www.linux-usb.org/usb.ids"
+            ],
+            "hash": [
+                "7d57df95dac449a9c021f8e774f4e7d7d22f8ab82bc5852f29873d3b58c27184",
+                "29fa9082f1377dd565232f891a47b87eb652cc8b87002c34b4b43142f9816e1d"
+            ]
         }
     },
     "autoupdate": {


### PR DESCRIPTION
Fixes #90 

Also downloads the optional but recommended `usb.ids` file to show friendly USB device names.