### PR TITLE
Move shortcuts into a subdirectory of `Programs\scoop`

### DIFF
--- a/bucket/bluescreenview.json
+++ b/bucket/bluescreenview.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "BlueScreenView.exe",
-            "BlueScreenView"
+            "NirSoft\\BlueScreenView"
         ]
     ]
 }

--- a/bucket/chromepass.json
+++ b/bucket/chromepass.json
@@ -13,7 +13,7 @@
     "shortcuts": [
         [
             "ChromePass.exe",
-            "ChromePass"
+            "NirSoft\\ChromePass"
         ]
     ]
 }

--- a/bucket/countrytraceroute.json
+++ b/bucket/countrytraceroute.json
@@ -13,7 +13,7 @@
     "shortcuts": [
         [
             "CountryTraceRoute.exe",
-            "CountryTraceRoute"
+            "NirSoft\\CountryTraceRoute"
         ]
     ]
 }

--- a/bucket/deviceioview.json
+++ b/bucket/deviceioview.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "DeviceIOView.exe",
-            "DeviceIOView"
+            "NirSoft\\DeviceIOView"
         ]
     ]
 }

--- a/bucket/devmanview.json
+++ b/bucket/devmanview.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "DevManView.exe",
-            "DevManView"
+            "NirSoft\\DevManView"
         ]
     ]
 }

--- a/bucket/dllexportviewer.json
+++ b/bucket/dllexportviewer.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "dllexp.exe",
-            "DLL Export Viewer"
+            "NirSoft\\DLL Export Viewer"
         ]
     ]
 }

--- a/bucket/dotnetresourcesextract.json
+++ b/bucket/dotnetresourcesextract.json
@@ -13,7 +13,7 @@
     "shortcuts": [
         [
             "DotNetResourcesExtract.exe",
-            "DotNetResourcesExtract"
+            "NirSoft\\DotNetResourcesExtract"
         ]
     ]
 }

--- a/bucket/filetypesman.json
+++ b/bucket/filetypesman.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "FileTypesMan.exe",
-            "FileTypesMan"
+            "NirSoft\\FileTypesMan"
         ]
     ]
 }

--- a/bucket/firmwaretablesview.json
+++ b/bucket/firmwaretablesview.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "FirmwareTablesView.exe",
-            "FirmwareTablesView"
+            "NirSoft\\FirmwareTablesView"
         ]
     ]
 }

--- a/bucket/gacview.json
+++ b/bucket/gacview.json
@@ -13,7 +13,7 @@
     "shortcuts": [
         [
             "gacview.exe",
-            "GACView"
+            "NirSoft\\GACView"
         ]
     ]
 }

--- a/bucket/gdiview.json
+++ b/bucket/gdiview.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "GDIView.exe",
-            "GDIView"
+            "NirSoft\\GDIView"
         ]
     ]
 }

--- a/bucket/heapmemview.json
+++ b/bucket/heapmemview.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "HeapMemView.exe",
-            "HeapMemView"
+            "NirSoft\\HeapMemView"
         ]
     ]
 }

--- a/bucket/iepassview.json
+++ b/bucket/iepassview.json
@@ -13,7 +13,7 @@
     "shortcuts": [
         [
             "iepv.exe",
-            "IE PassView"
+            "NirSoft\\IE PassView"
         ]
     ]
 }

--- a/bucket/insideclipboard.json
+++ b/bucket/insideclipboard.json
@@ -13,7 +13,7 @@
     "shortcuts": [
         [
             "InsideClipboard.exe",
-            "InsideClipboard"
+            "NirSoft\\InsideClipboard"
         ]
     ]
 }

--- a/bucket/installeddriverlist.json
+++ b/bucket/installeddriverlist.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "InstalledDriversList.exe",
-            "InstalledDriversList"
+            "NirSoft\\InstalledDriversList"
         ]
     ]
 }

--- a/bucket/installedpackagesview.json
+++ b/bucket/installedpackagesview.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "InstalledPackagesView.exe",
-            "InstalledPackagesView"
+            "NirSoft\\InstalledPackagesView"
         ]
     ]
 }

--- a/bucket/netrouteview.json
+++ b/bucket/netrouteview.json
@@ -13,7 +13,7 @@
     "shortcuts": [
         [
             "NetRouteView.exe",
-            "NetRouteView"
+            "NirSoft\\NetRouteView"
         ]
     ]
 }

--- a/bucket/networklatencyview.json
+++ b/bucket/networklatencyview.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "NetworkLatencyView.exe",
-            "NetworkLatencyView"
+            "NirSoft\\NetworkLatencyView"
         ]
     ]
 }

--- a/bucket/openedfilesview.json
+++ b/bucket/openedfilesview.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "OpenedFilesView.exe",
-            "OpenedFilesView"
+            "NirSoft\\OpenedFilesView"
         ]
     ]
 }

--- a/bucket/passwordfox.json
+++ b/bucket/passwordfox.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "PasswordFox.exe",
-            "PasswordFox"
+            "NirSoft\\PasswordFox"
         ]
     ]
 }

--- a/bucket/pinginfoview.json
+++ b/bucket/pinginfoview.json
@@ -13,7 +13,7 @@
     "shortcuts": [
         [
             "PingInfoView.exe",
-            "PingInfoView"
+            "NirSoft\\PingInfoView"
         ]
     ]
 }

--- a/bucket/produkey.json
+++ b/bucket/produkey.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "ProduKey.exe",
-            "ProduKey"
+            "NirSoft\\ProduKey"
         ]
     ]
 }

--- a/bucket/quicksetdns.json
+++ b/bucket/quicksetdns.json
@@ -13,7 +13,7 @@
     "shortcuts": [
         [
             "QuickSetDNS.exe",
-            "QuickSetDNS"
+            "NirSoft\\QuickSetDNS"
         ]
     ]
 }

--- a/bucket/regdllview.json
+++ b/bucket/regdllview.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "RegDllView.exe",
-            "RegDllView"
+            "NirSoft\\RegDllView"
         ]
     ]
 }

--- a/bucket/regfromapp.json
+++ b/bucket/regfromapp.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "RegFromApp.exe",
-            "RegFromApp"
+            "NirSoft\\RegFromApp"
         ]
     ]
 }

--- a/bucket/regscanner.json
+++ b/bucket/regscanner.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "RegScanner.exe",
-            "RegScanner"
+            "NirSoft\\RegScanner"
         ]
     ]
 }

--- a/bucket/resourcesextract.json
+++ b/bucket/resourcesextract.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "ResourcesExtract.exe",
-            "ResourcesExtract"
+            "NirSoft\\ResourcesExtract"
         ]
     ]
 }

--- a/bucket/routerpasswordrecovery.json
+++ b/bucket/routerpasswordrecovery.json
@@ -13,7 +13,7 @@
     "shortcuts": [
         [
             "RouterPassView.exe",
-            "RouterPassView"
+            "NirSoft\\RouterPassView"
         ]
     ]
 }

--- a/bucket/runasdate.json
+++ b/bucket/runasdate.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "RunAsDate.exe",
-            "RunAsDate"
+            "NirSoft\\RunAsDate"
         ]
     ]
 }

--- a/bucket/shellexview.json
+++ b/bucket/shellexview.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "shexview.exe",
-            "ShellExView"
+            "NirSoft\\ShellExView"
         ]
     ]
 }

--- a/bucket/shellmenuview.json
+++ b/bucket/shellmenuview.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "shmnview.exe",
-            "ShellMenuView"
+            "NirSoft\\ShellMenuView"
         ]
     ]
 }

--- a/bucket/simpledebugger.json
+++ b/bucket/simpledebugger.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "SimpleProgramDebugger.exe",
-            "SimpleProgramDebugger"
+            "NirSoft\\SimpleProgramDebugger"
         ]
     ]
 }

--- a/bucket/socketsniff.json
+++ b/bucket/socketsniff.json
@@ -13,7 +13,7 @@
     "shortcuts": [
         [
             "SocketSniff.exe",
-            "SocketSniff"
+            "NirSoft\\SocketSniff"
         ]
     ]
 }

--- a/bucket/soundvolumeview.json
+++ b/bucket/soundvolumeview.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "SoundVolumeView.exe",
-            "SoundVolumeView"
+            "NirSoft\\SoundVolumeView"
         ]
     ]
 }

--- a/bucket/specialfoldersview.json
+++ b/bucket/specialfoldersview.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "SpecialFoldersView.exe",
-            "SpecialFoldersView"
+            "NirSoft\\SpecialFoldersView"
         ]
     ]
 }

--- a/bucket/sysexporter.json
+++ b/bucket/sysexporter.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "sysexp.exe",
-            "SysExporter"
+            "NirSoft\\SysExporter"
         ]
     ]
 }

--- a/bucket/taskschedulerview.json
+++ b/bucket/taskschedulerview.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "TaskSchedulerView.exe",
-            "TaskSchedulerView"
+            "NirSoft\\TaskSchedulerView"
         ]
     ]
 }

--- a/bucket/turnedontimesview.json
+++ b/bucket/turnedontimesview.json
@@ -13,7 +13,7 @@
     "shortcuts": [
         [
             "TurnedOnTimesView.exe",
-            "TurnedOnTimesView"
+            "NirSoft\\TurnedOnTimesView"
         ]
     ]
 }

--- a/bucket/uninstallview.json
+++ b/bucket/uninstallview.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "UninstallView.exe",
-            "UninstallView"
+            "NirSoft\\UninstallView"
         ]
     ]
 }

--- a/bucket/usbdeview.json
+++ b/bucket/usbdeview.json
@@ -40,7 +40,7 @@
     "shortcuts": [
         [
             "USBDeview.exe",
-            "USBDeview"
+            "NirSoft\\USBDeview"
         ]
     ]
 }

--- a/bucket/usblogview.json
+++ b/bucket/usblogview.json
@@ -10,5 +10,5 @@
     "bin": "USBLogView.exe",
     "url": "https://www.nirsoft.net/utils/usblogview.zip",
     "hash": "8ec630a9ed42389d73c1c82de05f0019f61baf7af81fc16de13c6643eb07fd4d",
-    "shortcuts": [["USBLogView.exe", "USBLogView"]]
+    "shortcuts": [["USBLogView.exe", "NirSoft\\USBLogView"]]
 }

--- a/bucket/wakemeonlan.json
+++ b/bucket/wakemeonlan.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "WakeMeOnLan.exe",
-            "WakeMeOnLan"
+            "NirSoft\\WakeMeOnLan"
         ]
     ]
 }

--- a/bucket/webbrowserpassview.json
+++ b/bucket/webbrowserpassview.json
@@ -13,7 +13,7 @@
     "shortcuts": [
         [
             "WebBrowserPassView.exe",
-            "WebBrowserPassView"
+            "NirSoft\\WebBrowserPassView"
         ]
     ]
 }

--- a/bucket/whatinstartup.json
+++ b/bucket/whatinstartup.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "WhatInStartup.exe",
-            "WhatInStartup"
+            "NirSoft\\WhatInStartup"
         ]
     ]
 }

--- a/bucket/wifiinfoview.json
+++ b/bucket/wifiinfoview.json
@@ -13,7 +13,7 @@
     "shortcuts": [
         [
             "WifiInfoView.exe",
-            "WifiInfoView"
+            "NirSoft\\WifiInfoView"
         ]
     ]
 }

--- a/bucket/wirelesskeyview.json
+++ b/bucket/wirelesskeyview.json
@@ -28,7 +28,7 @@
     "shortcuts": [
         [
             "WirelessKeyView.exe",
-            "WirelessKeyView"
+            "NirSoft\\WirelessKeyView"
         ]
     ]
 }


### PR DESCRIPTION
This significantly reduces clutter when more than a few tools are installed