### PR TITLE
Add WinExplorer

### DIFF
--- a/bucket/winexplorer.json
+++ b/bucket/winexplorer.json
@@ -9,10 +9,10 @@
     "autoupdate": {
                 "url": "https://www.nirsoft.net/utils/winexp.zip"
     },
-    "bin": "WinExplorer.exe",
+    "bin": "winexp.exe",
     "shortcuts": [
         [
-            "WinExplorer.exe",
+            "winexp.exe",
             "NirSoft\\WinExplorer"
         ]
     ]

--- a/bucket/winexplorer.json
+++ b/bucket/winexplorer.json
@@ -1,0 +1,19 @@
+{
+    "homepage": "https://www.nirsoft.net/utils/winexp.html",
+    "checkver": "WinExplorer v(\\d+\\.\\d\\d)",
+    "version": "1.30",
+    "license": "freeware",
+    "description": "WinExplorer is a utility that shows all system's windows in hierarchical display. For every window in the hierarchy, you can view its properties, like handle, class name, caption, size, position and more. You can also modify some properties, like Caption and Visible/Enabled.",
+    "url": "https://www.nirsoft.net/utils/winexp.zip",
+    "hash": "12403572FCF3676335C59B72887FA2910E616973938630DC34E7B856AAF34075",
+    "autoupdate": {
+                "url": "https://www.nirsoft.net/utils/winexp.zip"
+    },
+    "bin": "WinExplorer.exe",
+    "shortcuts": [
+        [
+            "WinExplorer.exe",
+            "NirSoft\\WinExplorer"
+        ]
+    ]
+}


### PR DESCRIPTION
WinExplorer is a utility that shows all system's windows in hierarchical display. For every window in the hierarchy, you can view its properties, like handle, class name, caption, size, position and more. You can also modify some properties, like Caption and Visible/Enabled. Closes issue https://github.com/kodybrown/scoop-nirsoft/issues/127

![image](https://user-images.githubusercontent.com/65787561/169709373-f3cb53ed-ff37-4fa8-9c33-0d2e75f62c1e.png)

https://www.nirsoft.net/utils/winexp.html