### PR TITLE
Update NetRouteView to 1.40

### DIFF
--- a/bucket/netrouteview.json
+++ b/bucket/netrouteview.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://www.nirsoft.net/utils/network_route_view.html",
     "checkver": "NetRouteView v(\\d+\\.\\d\\d)",
-    "version": "1.35",
+    "version": "1.40",
     "license": "freeware",
     "description": "NetRouteView is a GUI alternative to the standard route utility (Route.exe) of Windows operating system. It displays the list of all routes on your current network, including the destination, mask, gateway, interface IP address, metric value, type, protocol, age (in seconds), interface name, and the MAC address. NetRouteView also allows you to easily add new routes, as well as to remove or modify existing static routes.",
     "url": "https://www.nirsoft.net/utils/netrouteview.zip",
-    "hash": "c1a4a90097d1e589d4e4cc90a91256018232462fbc86e5849ac41bac8b88751e",
+    "hash": "266d4972ef251f950d63f3c5491da99dffceb3c505f7d8118fc9eccdb476101a",
     "autoupdate": {
         "url": "https://www.nirsoft.net/utils/netrouteview.zip"
     },


### PR DESCRIPTION
As per latest today April 13, 2023.
SHA-256 hash `266d4972ef251f950d63f3c5491da99dffceb3c505f7d8118fc9eccdb476101a`.